### PR TITLE
Adding External property Fix #13

### DIFF
--- a/data/runtime.acf.config
+++ b/data/runtime.acf.config
@@ -9,6 +9,7 @@ schemaVersion="1.0" >
    <Process name="runtime"
             binaryPath="/opt/plcnext/projects/runtime/runtime"
             workingDirectory="/opt/plcnext/projects/runtime"
+            external="true"
             args="runtime.acf.settings"/>
 </Processes>
 


### PR DESCRIPTION
Optional attribute to specify a process as an external executable, thus it is not the standard Acf executable Arp.System.Application.